### PR TITLE
Fix "using $this when not in object context" error

### DIFF
--- a/eppr.php
+++ b/eppr.php
@@ -170,7 +170,7 @@ function eppr_RegisterDomain($params = array())
             throw new exception($r->cd[0]->name . ' ' . $reason);
         }
 
-        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
+        if (empty($params['icannMinimumDataSet']) || $params['icannMinimumDataSet'] != 'on') {
             $contacts = array();
             foreach(array(
                 'registrant',
@@ -328,7 +328,7 @@ function eppr_RegisterDomain($params = array())
         $to[] = htmlspecialchars($params['ns4']);
         $from[] = '/{{ ns5 }}/';
         $to[] = htmlspecialchars($params['ns5']);        
-        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
+        if (empty($params['icannMinimumDataSet']) || $params['icannMinimumDataSet'] != 'on') {
             $from[] = '/{{ cID_1 }}/';
             $to[] = htmlspecialchars($contacts[1]);
             $from[] = '/{{ cID_2 }}/';
@@ -345,7 +345,7 @@ function eppr_RegisterDomain($params = array())
         $to[] = htmlspecialchars($params['registrarprefix'] . '-domain-create-' . $clTRID);
         $from[] = "/<\w+:\w+>\s*<\/\w+:\w+>\s+/ims";
         $to[] = '';
-        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
+        if (empty($params['icannMinimumDataSet']) || $params['icannMinimumDataSet'] != 'on') {
             $xml = preg_replace($from, $to, '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
     <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -410,7 +410,7 @@ function eppr_RegisterDomain($params = array())
             _eppr_log('Error: Required module is not active.');
         }
 
-        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
+        if (empty($params['icannMinimumDataSet']) || $params['icannMinimumDataSet'] != 'on') {
             // Insert contacts and get their IDs
             $contactIds = insertContacts($params, $contacts);
             

--- a/eppr.php
+++ b/eppr.php
@@ -170,7 +170,7 @@ function eppr_RegisterDomain($params = array())
             throw new exception($r->cd[0]->name . ' ' . $reason);
         }
 
-        if (empty($this->params['icannMinimumDataSet']) || $this->params['icannMinimumDataSet'] != 'on') {
+        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
             $contacts = array();
             foreach(array(
                 'registrant',
@@ -328,7 +328,7 @@ function eppr_RegisterDomain($params = array())
         $to[] = htmlspecialchars($params['ns4']);
         $from[] = '/{{ ns5 }}/';
         $to[] = htmlspecialchars($params['ns5']);        
-        if (empty($this->params['icannMinimumDataSet']) || $this->params['icannMinimumDataSet'] != 'on') {
+        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
             $from[] = '/{{ cID_1 }}/';
             $to[] = htmlspecialchars($contacts[1]);
             $from[] = '/{{ cID_2 }}/';
@@ -345,7 +345,7 @@ function eppr_RegisterDomain($params = array())
         $to[] = htmlspecialchars($params['registrarprefix'] . '-domain-create-' . $clTRID);
         $from[] = "/<\w+:\w+>\s*<\/\w+:\w+>\s+/ims";
         $to[] = '';
-        if (empty($this->params['icannMinimumDataSet']) || $this->params['icannMinimumDataSet'] != 'on') {
+        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
             $xml = preg_replace($from, $to, '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
     <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -410,7 +410,7 @@ function eppr_RegisterDomain($params = array())
             _eppr_log('Error: Required module is not active.');
         }
 
-        if (empty($this->params['icannMinimumDataSet']) || $this->params['icannMinimumDataSet'] != 'on') {
+        if (empty(params['icannMinimumDataSet']) || params['icannMinimumDataSet'] != 'on') {
             // Insert contacts and get their IDs
             $contactIds = insertContacts($params, $contacts);
             


### PR DESCRIPTION
Hello,

I encountered an error during creation of a new domain name from WHMCS:

```
Error: Error: Using $this when not in object context in /home/whmcs/www/modules/registrars/eppr/eppr.php:173 

Stack trace: 
#0 /home/whmcs/www/vendor/whmcs/whmcs-foundation/lib/Module/AbstractModule.php(0): eppr_RegisterDomain() 
#1 /home/whmcs/www/vendor/whmcs/whmcs-foundation/lib/Module/Registrar.php(0): WHMCS\Module\AbstractModule->call() 
#2 /home/whmcs/www/includes/registrarfunctions.php(0): WHMCS\Module\Registrar->call() 
#3 /home/whmcs/www/admin/clientsdomainreg.php(0): RegRegisterDomain() #4 {main}
```

For some reason the code uses `$this` in a function, but it should only be used in a class methods.